### PR TITLE
feat(dashboard): integração Power BI via iframe no Dashboard.jsx

### DIFF
--- a/src/pages/dashboard/Dashboard.jsx
+++ b/src/pages/dashboard/Dashboard.jsx
@@ -2,7 +2,7 @@ import Bread from "../../components/bread/Bread";
 
 //Page que é acessada por ADMINISTRADORES, nela é renderizada um dashboard de powerBI por meio do iframe.
 const Dashboard = () => {
-  const iFrame = "https://app.powerbi.com/view?r=eyJrIjoiYTdlYmRhM2MtODVjZS00NjJhLWI3ZWMtOTMzYjE0NWZhYmUzIiwidCI6IjJjZjdkNGQ1LWJkMWItNDk1Ni1hY2Y4LTI5OTUzOTliMjE2OCJ9";
+  const iFrame = "https://app.powerbi.com/groups/me/reports/b8352f04-9642-430b-8d0a-2dc20025c137/a1bcfa340e83bd87b5b0?experience=power-bi";
 
   return (
     <div className="container d-flex justify-content-center min-vh-100 user-select-none">
@@ -18,9 +18,9 @@ const Dashboard = () => {
             height="800"
             src={iFrame}
             frameBorder="0"
-            allowFullScreen="true"
+            allowFullScreen
             loading="eager"
-            sandbox="allow-scripts allow-same-origin"
+            //sandbox="allow-scripts allow-same-origin"
           ></iframe>
         </div>
       </div>


### PR DESCRIPTION
feat(dashboard): integração inicial com Power BI via iframe

Implementação da integração visual com o Power BI no frontend.

Adicionada página Dashboard.jsx com iframe embedado.
Link utilizado é interno (não público ainda).
Estrutura pronta para quando o dashboard for publicado.
Nenhuma alteração feita no backend.

Branch criada a partir do fork por conta de limitações de acesso ao repositório original.
